### PR TITLE
Fix bug in rake task file exclusion

### DIFF
--- a/lib/jshintrb/jshinttask.rb
+++ b/lib/jshintrb/jshinttask.rb
@@ -75,7 +75,7 @@ module Jshintrb
         result = []
         result += js_files.to_a if js_files
         result += FileList[ pattern ].to_a if pattern
-        result -= exclude_js_files.to_a if js_files
+        result -= exclude_js_files.to_a if exclude_js_files
         result -= FileList[ exclude_pattern ].to_a if exclude_pattern
         FileList[result]
     end


### PR DESCRIPTION
The "exclude_js_files" option would only work if "js_files" was also
set, which does not seem to be the desired behavior. For instance, this
patch allows specifying a pattern to match and then using
"exclude_js_files" to exclude specific files matched by the pattern.
