### PR TITLE
Upgrade to MultiJson 1.3

### DIFF
--- a/jshintrb.gemspec
+++ b/jshintrb.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec"
   s.add_runtime_dependency "rake"
 
-  s.add_dependency "multi_json"
+  s.add_dependency "multi_json", ">= 1.3"
   s.add_dependency "execjs"
 end

--- a/lib/jshintrb/lint.rb
+++ b/lib/jshintrb/lint.rb
@@ -51,9 +51,9 @@ module Jshintrb
 
       js = []
       if @options.nil? then
-        js << "JSHINT(#{MultiJson.encode(source)});"
+        js << "JSHINT(#{MultiJson.dump(source)});"
       else
-        js << "JSHINT(#{MultiJson.encode(source)}, #{MultiJson.encode(@options)});"
+        js << "JSHINT(#{MultiJson.dump(source)}, #{MultiJson.dump(@options)});"
       end
       js << "return JSHINT.errors;"
 


### PR DESCRIPTION
Upgrade to latest version of MultiJson and change calls to use ".dump"
instead of ".encode", which has been deprecated.
