### PR TITLE
Support .jshintrc

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ If you pass `:defaults` as option, it is the same as if you pass following
 }
 ```
 
+If you pass `:jshintrc` as option, `.jshintrc` file is loaded as option.
+
 ## TODO
 
  - add more tests

--- a/lib/jshintrb/lint.rb
+++ b/lib/jshintrb/lint.rb
@@ -35,6 +35,7 @@ module Jshintrb
       if options == :defaults then
         @options = DEFAULTS.dup
       elsif options == :jshintrc then
+        raise '`.jshintrc` is not exist on current working directory.' unless File.exist?('./.jshintrc')
         @options = MultiJson.load(File.read('./.jshintrc'))
       elsif options.instance_of? Hash then
         @options = options.dup

--- a/lib/jshintrb/lint.rb
+++ b/lib/jshintrb/lint.rb
@@ -34,6 +34,8 @@ module Jshintrb
 
       if options == :defaults then
         @options = DEFAULTS.dup
+      elsif options == :jshintrc then
+        @options = MultiJson.load(File.read('./.jshintrc'))
       elsif options.instance_of? Hash then
         @options = options.dup
         # @options = DEFAULTS.merge(options)

--- a/spec/fixtures/.jshintrc
+++ b/spec/fixtures/.jshintrc
@@ -1,0 +1,3 @@
+{
+  "unused": true
+}

--- a/spec/jshintrb_spec.rb
+++ b/spec/jshintrb_spec.rb
@@ -6,7 +6,7 @@ def gen_file source, option, value
 end
 
 describe "Jshintrb" do
-  
+
   it "support options" do
     options = {
       :bitwise => "var a = 1|1;",
@@ -42,6 +42,14 @@ describe "Jshintrb" do
     source = "foo();"
     Jshintrb.lint(source, :defaults, [:foo]).length.should eq 0
     Jshintrb.lint(source, :defaults).length.should eq 1
+  end
+
+  it "supports .jshintrc" do
+    basedir = File.join(File.dirname(__FILE__), "fixtures")
+    source = "var hoge;"
+    Dir.chdir basedir do
+      Jshintrb.lint(source, :jshintrc).length.should eq 1
+    end
   end
 
 end


### PR DESCRIPTION
Original jSHint supports `.jshintrc`.
- http://jshint.com/docs/#usage
