### PR TITLE
Add default nil value for file argument

### DIFF
--- a/lib/jshintrb/reporter/default.rb
+++ b/lib/jshintrb/reporter/default.rb
@@ -2,7 +2,7 @@ module Jshintrb
   module Reporter
     class Default
 
-      def format errors, file
+      def format errors, file = nil
         result = ''
         indent = ''
         if file then


### PR DESCRIPTION
This function is called from `lib/jshintrb.rb` as `report = reporter.format errors` with no file argument. Since the function does not require the argument, setting a default value of `nil` offers a quick fix.
