### PR TITLE
Remove obsolete options

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,6 @@ If you pass `:defaults` as option, it is the same as if you pass following
   :regexp => true,
   :undef => true,
   :strict => true,
-  :trailing => true,
   :browser => true
 }
 ```

--- a/README.md
+++ b/README.md
@@ -58,7 +58,6 @@ If you pass `:defaults` as option, it is the same as if you pass following
   :noempty => true,
   :nonew => true,
   :plusplus => true,
-  :regexp => true,
   :undef => true,
   :strict => true,
   :browser => true

--- a/lib/jshintrb/lint.rb
+++ b/lib/jshintrb/lint.rb
@@ -24,7 +24,6 @@ module Jshintrb
       :regexp => true,
       :undef => true,
       :strict => true,
-      :trailing => true,
       :browser => true
     }
 

--- a/lib/jshintrb/lint.rb
+++ b/lib/jshintrb/lint.rb
@@ -21,7 +21,6 @@ module Jshintrb
       :noempty => true,
       :nonew => true,
       :plusplus => true,
-      :regexp => true,
       :undef => true,
       :strict => true,
       :browser => true

--- a/spec/jshintrb_spec.rb
+++ b/spec/jshintrb_spec.rb
@@ -23,7 +23,6 @@ describe "Jshintrb" do
       # :regexp => true,
       :undef => "if (a == 'a') { var b = 'b'; }"
       # :strict => true,
-      # :trailing => true,
       # :browser => true
     }
 

--- a/spec/jshintrb_spec.rb
+++ b/spec/jshintrb_spec.rb
@@ -20,7 +20,6 @@ describe "Jshintrb" do
       # :noempty => true,
       # :nonew => true,
       # :plusplus => true,
-      # :regexp => true,
       :undef => "if (a == 'a') { var b = 'b'; }"
       # :strict => true,
       # :browser => true


### PR DESCRIPTION
Both of these options seem to no longer have any effect within JSHint (and aren't listed anywhere in their current documentation).
