### PR TITLE
making jshint compatible with rake 11

### DIFF
--- a/lib/jshintrb/jshinttask.rb
+++ b/lib/jshintrb/jshinttask.rb
@@ -52,7 +52,7 @@ module Jshintrb
     def define # :nodoc:
 
       actual_name = Hash === name ? name.keys.first : name
-      unless ::Rake.application.last_comment
+      unless ::Rake.application.last_description
         desc "Run JShint"
       end
       task name do

--- a/lib/jshintrb/jshinttask.rb
+++ b/lib/jshintrb/jshinttask.rb
@@ -52,7 +52,7 @@ module Jshintrb
     def define # :nodoc:
 
       actual_name = Hash === name ? name.keys.first : name
-      unless ::Rake.application.last_description
+      unless ::Rake.application.last_description || ::Rake.application.last_comment
         desc "Run JShint"
       end
       task name do


### PR DESCRIPTION
# BUGFIX

This gem was causing our build to fail with rake 11.

```
rake aborted!
NoMethodError: undefined method `last_comment' for #<Rake::Application:0x007f6c4eedf960>
/home/runner/bijou/vendor/bundle/ruby/2.0.0/gems/rspec-core-3.4.3/lib/rspec/core/rake_task.rb:91:in `define'
/home/runner/bijou/vendor/bundle/ruby/2.0.0/gems/rspec-core-3.4.3/lib/rspec/core/rake_task.rb:71:in `initialize'
/home/runner/bijou/Rakefile:131:in `new'
/home/runner/bijou/Rakefile:131:in `<top (required)>'
(See full trace by running task with --trace)
```

This stems from the fact that that rake 11 uses `last_description` instead of `last_comment`
